### PR TITLE
JavaScript icon: use filled block, not outline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - **Support:** Composer (`composer.phar`), Cycript (`.cy`), DNS Zones (`.arpa`, `.zone`), Dust (`.dust`), Dylan (`.dylan`, `.dyl`, `.intr`, `.lid`), ECL (`.ecl`, `.eclxml`), Formatted (`.eam.fs`), Forth (`.4th`, `.fth`, `.forth`, `.frt`), G-code (`.gco`, `.gcode`), Grace (`.grace`), Graph Modelling Language (`.gml`)
 
 ### Changed
+- JavaScript icon is now a filled square, instead of a square outline
 - Generic config icon now used for `.conf` files instead of nginx logo [[`#331`](https://github.com/DanBrooker/file-icons/issues/331)]
 - Python icon is now blue instead of orange [[`#199`](https://github.com/DanBrooker/file-icons/issues/199)]
 - Visual Basic files now distinguished by Visual Studio icon

--- a/styles/icons.less
+++ b/styles/icons.less
@@ -79,7 +79,7 @@
 .h-icon               { .mf; content: "\f010"; }
 .haskell-icon         { .mf; content: "\f121"; }
 .java-icon            { .mf; content: "\f126"; font-size: medium; left: 2px; top: 2px; }
-.js-icon              { .mf; content: "\f128"; font-size: medium; }
+.js-icon              { .mf; content: "\f129"; font-size: large; }
 .objc-icon            { .mf; content: "\f13e"; font-size: medium; }
 .osx-icon             { .mf; content: "\f141"; left: 2px; }
 .perl-icon            { .mf; content: "\f142"; }


### PR DESCRIPTION
The current icon used for JavaScript-family files was the [default Mfizz JavaScript icon](http://fizzed.com/oss/font-mfizz/icon-javascript), which is a square icon with the letters "JS" in the bottom-right corner. The problem with this is that the outline is thin and the letters small, leading to a weak, hard-to-discern icon, especially at smaller sizes and on light backgrounds. This 'outline-style' icon also doesn't follow the style of most other icons set by the file-icons package, which are usually filled blocks, making the JS and even harder to identify at a glance, as well as looking out-of-place.

This pull request changes the icon used for JavaScript-family files to be the [Mfizz "JavaScript Alt" icon](http://fizzed.com/oss/font-mfizz/icon-javascript-alt), which is exactly like the standard JavaScript icon, except the square is filled-in, rather than being an outline. This icon is a lot easier to identify at a glance, and is more in keeping with the style of the other icons set by file-icons. Since it comes from the same font family as the previous JS icon, it also has minimal stylistic changes from the previous icon, beyond filling-in the square.

The icon manually has its `font-size` set to `large` (from the `.mf` default of `small`) to more closely match the size of the other file icons (12px vs. 14px in height; most other icons are around 15px).
